### PR TITLE
Enabled --skip-deployments-check when FORCE_NEW_DEPLOYMENT flag is enabled.

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -615,7 +615,9 @@ if [ "$BASH_SOURCE" == "$0" ]; then
     # Not required creation of new a task definition
     if [ $FORCE_NEW_DEPLOYMENT == true ]; then
         updateServiceForceNewDeployment
-        waitForGreenDeployment
+        if [[ $SKIP_DEPLOYMENTS_CHECK != true ]]; then
+          waitForGreenDeployment
+        fi
         exit 0
     fi
 


### PR DESCRIPTION
The script was lacking the ability to force new deployments while skipping the check which can hang when the drain time on applications are extended. (Application specific). I've updated the script to account for that.

